### PR TITLE
Expand Size struct, modify Vector3

### DIFF
--- a/TrueCraft.API/Size.cs
+++ b/TrueCraft.API/Size.cs
@@ -1,14 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
 namespace TrueCraft.API
 {
     /// <summary>
     /// Represents the size of an object in 3D space.
     /// </summary>
-    public struct Size
+    [StructLayout(LayoutKind.Explicit)]
+    public struct Size : IEquatable<Size>
     {
-        public double Depth;
-        public double Height;
+        [FieldOffset(0)]
         public double Width;
+        [FieldOffset(8)]
+        public double Height;
+        [FieldOffset(16)]
+        public double Depth;
 
+        #region Constructors
         public Size(double width, double height, double depth)
         {
             this.Width = width;
@@ -22,11 +30,160 @@ namespace TrueCraft.API
             this.Height = s.Height;
             this.Depth = s.Depth;
         }
+        #endregion
 
-        // TODO: More operators
+        #region Operators
         public static Size operator /(Size a, double b)
         {
-            return new Size(a.Width / b, a.Height / b, a.Depth / b);
+            return new Size(a.Width / b,
+                            a.Height / b,
+                            a.Depth / b);
+        }
+
+        public static Size operator *(Size a, double b)
+        {
+            return new Size(a.Width * b,
+                            a.Height * b,
+                            a.Depth * b);
+        }
+
+        public static Size operator %(Size a, double b)
+        {
+            return new Size(a.Width % b,
+                            a.Height % b,
+                            a.Depth % b);
+        }
+
+        public static Size operator +(Size a, double b)
+        {
+            return new Size(a.Width + b,
+                            a.Height + b,
+                            a.Depth + b);
+        }
+
+        public static Size operator -(Size a, double b)
+        {
+            return new Size(a.Width - b,
+                            a.Height - b,
+                            a.Depth - b);
+        }
+
+        public static Size operator /(double a, Size b)
+        {
+            return new Size(a/b.Width,
+                            a/b.Height,
+                            a/b.Depth);
+        }
+
+        public static Size operator *(double a, Size b)
+        {
+            return new Size(a * b.Width,
+                            a * b.Height,
+                            a * b.Depth);
+        }
+
+        public static Size operator %(double a, Size b)
+        {
+            return new Size(a % b.Width,
+                            a % b.Height,
+                            a % b.Depth);
+        }
+
+        public static Size operator +(double a, Size b)
+        {
+            return new Size(a + b.Width,
+                            a + b.Height,
+                            a + b.Depth);
+        }
+
+        public static Size operator -(double a, Size b)
+        {
+            return new Size(a - b.Width,
+                            a - b.Height,
+                            a - b.Depth);
+        }
+
+        public static Size operator /(Size a, Size b)
+        {
+            return new Size(a.Width / b.Width,
+                            a.Height / b.Height,
+                            a.Depth / b.Depth);
+        }
+
+        public static Size operator *(Size a, Size b)
+        {
+            return new Size(a.Width * b.Width,
+                            a.Height * b.Height,
+                            a.Depth * b.Depth);
+        }
+
+        public static Size operator %(Size a, Size b)
+        {
+            return new Size(a.Width % b.Width,
+                            a.Height % b.Height,
+                            a.Depth % b.Depth);
+        }
+
+        public static Size operator +(Size a, Size b)
+        {
+            return new Size(a.Width + b.Width,
+                            a.Height + b.Height,
+                            a.Depth + b.Depth);
+        }
+
+        public static Size operator -(Size a, Size b)
+        {
+            return new Size(a.Width - b.Width,
+                            a.Height - b.Height,
+                            a.Depth - b.Depth);
+        }
+
+        public static bool operator ==(Size a, Size b)
+        {
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(Size a, Size b)
+        {
+            return !(a.Equals(b));
+        }
+
+        public static implicit operator Size(Vector3 v)
+        {
+            return new Size(v.X, v.Y, v.Z);
+        }
+        #endregion
+
+        // TODO: Create math methods
+        
+        public bool Equals(Size other)
+        {
+            return this.Width == other.Width &&
+                   this.Height == other.Height &&
+                   this.Depth == other.Depth;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Size)
+                return Equals((Size) obj);
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 449;
+                hash = (hash * 457) ^ Width.GetHashCode();
+                hash = (hash * 457) ^ Height.GetHashCode();
+                hash = (hash * 457) ^ Depth.GetHashCode();
+                return hash;
+            }
+        }
+        public override string ToString()
+        {
+            return string.Format("<{0},{1},{2}>", Width, Height, Depth);
         }
     }
 }

--- a/TrueCraft.API/Vector3.cs
+++ b/TrueCraft.API/Vector3.cs
@@ -36,7 +36,7 @@ namespace TrueCraft.API
         }
 
         /// <summary>
-        /// Converts this Vector3 to a string in the format &lt;x, y, z&gt;.
+        /// Converts this Vector3 to a string in the format &lt;x,y,z&gt;.
         /// </summary>
         /// <returns></returns>
         public override string ToString()
@@ -292,9 +292,9 @@ namespace TrueCraft.API
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (obj.GetType() != typeof(Vector3)) return false;
-            return Equals((Vector3)obj);
+            if (obj is Vector3)
+                return Equals((Vector3)obj);
+            return false;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
TrueCraft.API/**Size.cs:**
* Add operators
* Implement IEquatable<Size>
* Override Object.Equals, .ToString and .GetHashcode

TrueCraft.API/**Vector3.cs:**
* Modify Object.Equals override: Using the `is` operator is faster than doing `(x.GetType() != typeof (y))`