### PR TITLE
Server port is now configurable

### DIFF
--- a/TrueCraft/Configuration.cs
+++ b/TrueCraft/Configuration.cs
@@ -26,6 +26,7 @@ namespace TrueCraft
             MOTD = ChatColor.Red + "Welcome to TrueCraft!";
             Debug = new DebugConfiguration();
             ServerPort = 25565;
+            ServerAddress = "0.0.0.0";
         }
 
         [YamlMember(Alias="motd")]
@@ -34,6 +35,9 @@ namespace TrueCraft
         [YamlMember(Alias="serverPort")]
         public int ServerPort {get; set; }
 
+        [YamlMember(Alias="serverAddress")]
+        public string ServerAddress{get; set; }
+        
         [YamlMember(Alias="debug")]
         public DebugConfiguration Debug { get; set; }
     }

--- a/TrueCraft/Configuration.cs
+++ b/TrueCraft/Configuration.cs
@@ -25,10 +25,14 @@ namespace TrueCraft
         {
             MOTD = ChatColor.Red + "Welcome to TrueCraft!";
             Debug = new DebugConfiguration();
+            ServerPort = 25565;
         }
 
         [YamlMember(Alias="motd")]
         public string MOTD { get; set; }
+
+        [YamlMember(Alias="serverPort")]
+        public int ServerPort {get; set; }
 
         [YamlMember(Alias="debug")]
         public DebugConfiguration Debug { get; set; }

--- a/TrueCraft/Program.cs
+++ b/TrueCraft/Program.cs
@@ -67,7 +67,7 @@ namespace TrueCraft
             #endif
             CommandManager = new CommandManager();
             Server.ChatMessageReceived += HandleChatMessageReceived;
-            Server.Start(new IPEndPoint(IPAddress.Any, 25565));
+            Server.Start(new IPEndPoint(IPAddress.Any, Configuration.ServerPort));
             Console.CancelKeyPress += HandleCancelKeyPress;
             while (true)
             {

--- a/TrueCraft/Program.cs
+++ b/TrueCraft/Program.cs
@@ -67,7 +67,7 @@ namespace TrueCraft
             #endif
             CommandManager = new CommandManager();
             Server.ChatMessageReceived += HandleChatMessageReceived;
-            Server.Start(new IPEndPoint(IPAddress.Any, Configuration.ServerPort));
+            Server.Start(new IPEndPoint(IPAddress.Parse(Configuration.ServerAddress), Configuration.ServerPort));
             Console.CancelKeyPress += HandleCancelKeyPress;
             while (true)
             {


### PR DESCRIPTION
Added ServerPort property to the Configuration object and tagged it to
read the serverPort definition in the YAML config file. Set the default
to 25565