### PR TITLE
Fixed server crash when sending "/" without command

### DIFF
--- a/TrueCraft/Program.cs
+++ b/TrueCraft/Program.cs
@@ -119,14 +119,16 @@ namespace TrueCraft
 
         static void HandleChatMessageReceived(object sender, ChatMessageEventArgs e)
         {
-            if (e.Message.StartsWith("/"))
-            {
-                e.PreventDefault = true;
-                var messageArray = e.Message.TrimStart('/')
-                    .Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
-                CommandManager.HandleCommand(e.Client, messageArray[0], messageArray);
-                return;
-            }
+            if (!e.Message.StartsWith("/")) return;
+
+            var commandWithoutSlash = e.Message.TrimStart('/');
+            var messageArray = commandWithoutSlash
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (messageArray.Length <= 0) return;
+
+            CommandManager.HandleCommand(e.Client, messageArray[0], messageArray);
+            e.PreventDefault = true;
         }
     }
 }


### PR DESCRIPTION
okay, fixed this crash in the meantime

(scenario: log in to client, press 'T', then '/' and finally '<enter>')

server will no longer try to execute a command when messageArray[0] doesn't exist

the 'invalid' command still works, just sending '/' in chat will now broadcast it as a chat message