### PR TITLE
Command case sensitivity

### DIFF
--- a/TrueCraft.API/Server/ICommand.cs
+++ b/TrueCraft.API/Server/ICommand.cs
@@ -11,7 +11,7 @@ namespace TrueCraft.API.Server
         string Name { get; }
         string Description { get; }
         string[] Aliases { get; }
-        void Handle(IRemoteClient Client, string Alias, string[] Arguments);
-        void Help(IRemoteClient Client, string Alias, string[] Arguments);
+        void Handle(IRemoteClient Client, string alias, string[] arguments);
+        void Help(IRemoteClient client, string alias, string[] arguments);
     }
 }

--- a/TrueCraft/Commands/Command.cs
+++ b/TrueCraft/Commands/Command.cs
@@ -15,8 +15,8 @@ namespace TrueCraft.Commands
 
         public virtual string[] Aliases { get { return new string[0]; } }
 
-        public virtual void Handle(IRemoteClient Client, string Alias, string[] Arguments) { Help(Client, Alias, Arguments); }
+        public virtual void Handle(IRemoteClient Client, string alias, string[] arguments) { Help(Client, alias, arguments); }
 
-        public virtual void Help(IRemoteClient Client, string Alias, string[] Arguments) { Client.SendMessage("Command \"" + Alias + "\" is not functional!"); }
+        public virtual void Help(IRemoteClient client, string alias, string[] arguments) { client.SendMessage("Command \"" + alias + "\" is not functional!"); }
     }
 }

--- a/TrueCraft/Commands/DebugCommands.cs
+++ b/TrueCraft/Commands/DebugCommands.cs
@@ -26,19 +26,19 @@ namespace TrueCraft.Commands
             get { return new string[0]; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (Arguments.Length != 0)
+            if (arguments.Length != 0)
             {
-                Help(Client, Alias, Arguments);
+                Help(Client, alias, arguments);
                 return;
             }
             Client.SendMessage(Client.Entity.Position.ToString());
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("/pos: Shows your position.");
+            client.SendMessage("/pos: Shows your position.");
         }
     }
 
@@ -59,19 +59,19 @@ namespace TrueCraft.Commands
             get { return new string[0]; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (Arguments.Length != 0)
+            if (arguments.Length != 0)
             {
-                Help(Client, Alias, Arguments);
+                Help(Client, alias, arguments);
                 return;
             }
             Client.EnableLogging = !Client.EnableLogging;
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("/pos: Toggles client logging.");
+            client.SendMessage("/pos: Toggles client logging.");
         }
     }
 
@@ -92,39 +92,39 @@ namespace TrueCraft.Commands
             get { return new string[0]; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            switch (Arguments.Length)
+            switch (arguments.Length)
             {
                 case 1:
                     Client.SendMessage(Client.World.Time.ToString());
                     break;
                 case 3:
-                    if (!Arguments[1].Equals("set"))
-                        Help(Client, Alias, Arguments);
+                    if (!arguments[1].Equals("set"))
+                        Help(Client, alias, arguments);
 
                     int newTime;
 
-                    if(!Int32.TryParse(Arguments[2], out newTime))
-                        Help(Client, Alias, Arguments);
+                    if(!Int32.TryParse(arguments[2], out newTime))
+                        Help(Client, alias, arguments);
 
                     Client.World.Time = newTime;
 
-                    Client.SendMessage(string.Format("Setting time to {0}", Arguments[2]));
+                    Client.SendMessage(string.Format("Setting time to {0}", arguments[2]));
 
                     foreach (var client in Client.Server.Clients.Where(c => c.World.Equals(Client.World)))
                         client.QueuePacket(new TimeUpdatePacket(newTime));
                     
                     break;
                 default:
-                    Help(Client, Alias, Arguments);
+                    Help(Client, alias, arguments);
                     break;
             }
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("/time: Shows the current time.");
+            client.SendMessage("/time: Shows the current time.");
         }
     }
 
@@ -145,19 +145,19 @@ namespace TrueCraft.Commands
             get { return new string[0]; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (Arguments.Length != 1)
+            if (arguments.Length != 1)
             {
-                Help(Client, Alias, Arguments);
+                Help(Client, alias, arguments);
                 return;
             }
             Client.QueuePacket(new WindowItemsPacket(0, Client.Inventory.GetSlots()));
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("/reinv: Resends your inventory.");
+            client.SendMessage("/reinv: Resends your inventory.");
         }
     }
 }

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -47,9 +47,9 @@ namespace TrueCraft.Commands
 #endif
 
             short id;
-            sbyte count;
+            int count;
 
-            if (short.TryParse(itemid, out id) && sbyte.TryParse(amount, out count))
+            if (short.TryParse(itemid, out id) && Int32.TryParse(amount, out count))
             {
                 if (receivingPlayer == null)
                 {
@@ -64,7 +64,21 @@ namespace TrueCraft.Commands
                 }
 
                 var inventory = receivingPlayer.Inventory as InventoryWindow;
-                if (inventory != null) inventory.PickUpStack(new ItemStack(id, count));
+                if (inventory != null)
+                {
+                    sbyte toAdd;
+                    while (count > 0)
+                    {
+                        if (count >= 64)
+                            toAdd = 64;
+                        else
+                            toAdd = (sbyte)count;
+
+                        count -= toAdd;
+
+                        inventory.PickUpStack(new ItemStack(id, toAdd));
+                    }
+                }
             }
         }
 

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -26,18 +26,18 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient client, string alias, string[] arguments)
         {
-            var regexMatch = GetValuesFromArguments(arguments);
-            if (regexMatch == null)
+            if (arguments.Length < 3)
             {
                 Help(client, alias, arguments);
                 return;
             }
 
-            string  username    = regexMatch.Groups[1].ToString(),
-                    itemid      = regexMatch.Groups[2].ToString(),
-                    amount      = regexMatch.Groups[4].ToString(); // match 3 is the amount with the leading space
+            string  username    = arguments[1],
+                    itemid      = arguments[2],
+                    amount      = "1";
 
-            if (String.IsNullOrEmpty(amount)) amount = "1"; // default to 1 when amount is omitted
+            if(arguments.Length >= 4)
+                    amount = arguments[3];
             
             var receivingPlayer =
                 client.Server.Clients.FirstOrDefault(c => String.Equals(c.Username, username, StringComparison.CurrentCultureIgnoreCase));
@@ -75,19 +75,6 @@ namespace TrueCraft.Commands
                         inventory.PickUpStack(new ItemStack(id, toAdd));
                     }
                 }
-            }
-        }
-
-        private Match GetValuesFromArguments(string[] arguments)
-        {
-            try
-            {
-                var myRegex = new Regex(@"^give ([a-zA-Z0-9_\.]+) ([0-9]+)( ([0-9]+))?$", RegexOptions.IgnoreCase);
-                return myRegex.Matches(String.Join(" ", arguments)).Cast<Match>().First(myMatch => myMatch.Success);
-            }
-            catch (InvalidOperationException)
-            {
-                return null;
             }
         }
 

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -51,7 +51,7 @@ namespace TrueCraft.Commands
                 }
 
                 var inventory = receiver.Inventory as InventoryWindow;
-                inventory.PickUpStack(new ItemStack(id, count));
+                if (inventory != null) inventory.PickUpStack(new ItemStack(id, count));
             }
         }
 

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -75,7 +75,11 @@ namespace TrueCraft.Commands
                         inventory.PickUpStack(new ItemStack(id, toAdd));
                     }
                 }
+
+                return;
             }
+
+            Help(client, alias, arguments);
         }
 
         public override void Help(IRemoteClient client, string alias, string[] arguments)

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -33,7 +33,7 @@ namespace TrueCraft.Commands
                 return;
             }
             
-            var receiver = Client.Server.Clients.SingleOrDefault(c => c.Username == Arguments[1]);
+            var receiver = Client.Server.Clients.SingleOrDefault(c => String.Equals(c.Username, Arguments[1], StringComparison.CurrentCultureIgnoreCase));
             short id;
             sbyte count;
             if (short.TryParse(Arguments[2], out id) && sbyte.TryParse(Arguments[3], out count))

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -42,10 +42,6 @@ namespace TrueCraft.Commands
             var receivingPlayer =
                 client.Server.Clients.FirstOrDefault(c => String.Equals(c.Username, username, StringComparison.CurrentCultureIgnoreCase));
 
-#if DEBUG
-            client.SendMessage(string.Format("username: {0}, item: {1}, amount: {2}", username, itemid, amount));
-#endif
-
             short id;
             int count;
 

--- a/TrueCraft/Commands/HelpCommand.cs
+++ b/TrueCraft/Commands/HelpCommand.cs
@@ -19,15 +19,15 @@ namespace TrueCraft.Commands
             get { return "Command help menu."; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (Arguments.Length < 1)
+            if (arguments.Length < 1)
             {
-                Help(Client, Alias, Arguments);
+                Help(Client, alias, arguments);
                 return;
             }
 
-            string Identifier = Arguments[0];
+            string Identifier = arguments[0];
             ICommand Found = null;
             if ((Found = Program.CommandManager.FindByName(Identifier)) != null)
             {
@@ -46,7 +46,7 @@ namespace TrueCraft.Commands
                 HelpPage(Client, PageNumber);
                 return;
             }
-            Help(Client, Alias, Arguments);
+            Help(Client, alias, arguments);
         }
 
         public void HelpPage(IRemoteClient Client, int Page)
@@ -73,9 +73,9 @@ namespace TrueCraft.Commands
             }
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("Correct usage is /" + Alias + " <page#/command> [command arguments]");
+            client.SendMessage("Correct usage is /" + alias + " <page#/command> [command arguments]");
         }
     }
 }

--- a/TrueCraft/Commands/PingCommand.cs
+++ b/TrueCraft/Commands/PingCommand.cs
@@ -18,14 +18,14 @@ namespace TrueCraft.Commands
             get { return "Ping pong"; }
         }
 
-        public override void Handle(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
             Client.SendMessage("Pong!");
         }
 
-        public override void Help(IRemoteClient Client, string Alias, string[] Arguments)
+        public override void Help(IRemoteClient client, string alias, string[] arguments)
         {
-            Client.SendMessage("Correct usage is /" + Alias);
+            client.SendMessage("Correct usage is /" + alias);
         }
     }
 }


### PR DESCRIPTION
I'm on fire tonight! This one looks big, but it's really the amount of occurrences of the capitalized parameters :relaxed: 

- /give
  - Now validating /give syntax with a regex, might be handy for other commands, too!
  - Fixed case-sensitivity for username in /give
  - Added possibility to /give more than 64 units at once
  - Amount is now optional (default: 1)
- some other stuff I happened to come across
  - Fixed a lot of capitalization in argument names
  - Prevented unlikely (but possible) nullpointerexception