### PR TITLE
Fixed HelpCommand behaviour

### DIFF
--- a/TrueCraft/Commands/DebugCommands.cs
+++ b/TrueCraft/Commands/DebugCommands.cs
@@ -28,7 +28,7 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (arguments.Length != 0)
+            if (arguments.Length != 1)
             {
                 Help(Client, alias, arguments);
                 return;
@@ -61,7 +61,7 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (arguments.Length != 0)
+            if (arguments.Length != 1)
             {
                 Help(Client, alias, arguments);
                 return;

--- a/TrueCraft/Commands/HelpCommand.cs
+++ b/TrueCraft/Commands/HelpCommand.cs
@@ -27,7 +27,13 @@ namespace TrueCraft.Commands
                 return;
             }
 
-            string Identifier = arguments[0];
+            string Identifier;
+
+            if (arguments.Length > 1)
+                Identifier = arguments[1];
+            else
+                Identifier = "0";
+
             ICommand Found = null;
             if ((Found = Program.CommandManager.FindByName(Identifier)) != null)
             {


### PR DESCRIPTION
When I entered the game I decided to see which commands where available. `/help` gave me help usage. But when I wrote `/help 1` or `/help give` it still gave me help usage. The method `HelpCommand.Handle(...)` was comparing `arguments[0]`, which is basically "help", against command names. So I fixed it.