### PR TITLE
Fixed command arguments to exclude command name.

### DIFF
--- a/TrueCraft/Commands/DebugCommands.cs
+++ b/TrueCraft/Commands/DebugCommands.cs
@@ -28,7 +28,7 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (arguments.Length != 1)
+            if (arguments.Length != 0)
             {
                 Help(Client, alias, arguments);
                 return;
@@ -61,7 +61,7 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (arguments.Length != 1)
+            if (arguments.Length != 0)
             {
                 Help(Client, alias, arguments);
                 return;
@@ -96,21 +96,21 @@ namespace TrueCraft.Commands
         {
             switch (arguments.Length)
             {
-                case 1:
+                case 0:
                     Client.SendMessage(Client.World.Time.ToString());
                     break;
-                case 3:
-                    if (!arguments[1].Equals("set"))
+                case 2:
+                    if (!arguments[0].Equals("set"))
                         Help(Client, alias, arguments);
 
                     int newTime;
 
-                    if(!Int32.TryParse(arguments[2], out newTime))
+                    if(!Int32.TryParse(arguments[1], out newTime))
                         Help(Client, alias, arguments);
 
                     Client.World.Time = newTime;
 
-                    Client.SendMessage(string.Format("Setting time to {0}", arguments[2]));
+                    Client.SendMessage(string.Format("Setting time to {0}", arguments[1]));
 
                     foreach (var client in Client.Server.Clients.Where(c => c.World.Equals(Client.World)))
                         client.QueuePacket(new TimeUpdatePacket(newTime));
@@ -147,7 +147,7 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient Client, string alias, string[] arguments)
         {
-            if (arguments.Length != 1)
+            if (arguments.Length != 0)
             {
                 Help(Client, alias, arguments);
                 return;

--- a/TrueCraft/Commands/GiveCommand.cs
+++ b/TrueCraft/Commands/GiveCommand.cs
@@ -25,18 +25,18 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient client, string alias, string[] arguments)
         {
-            if (arguments.Length < 3)
+            if (arguments.Length < 2)
             {
                 Help(client, alias, arguments);
                 return;
             }
 
-            string  username    = arguments[1],
-                    itemid      = arguments[2],
+            string  username    = arguments[0],
+                    itemid      = arguments[1],
                     amount      = "1";
 
-            if(arguments.Length >= 4)
-                    amount = arguments[3];
+            if(arguments.Length >= 3)
+                    amount = arguments[2];
             
             var receivingPlayer = GetPlayerByName(client, username);
 

--- a/TrueCraft/Commands/GiveMeCommand.cs
+++ b/TrueCraft/Commands/GiveMeCommand.cs
@@ -21,17 +21,17 @@ namespace TrueCraft.Commands
 
         public override void Handle(IRemoteClient client, string alias, string[] arguments)
         {
-            if (arguments.Length < 2)
+            if (arguments.Length < 1)
             {
                 Help(client, alias, arguments);
                 return;
             }
 
-            string itemid = arguments[1],
+            string itemid = arguments[0],
                 amount = "1";
 
-            if (arguments.Length >= 3)
-                amount = arguments[2];
+            if (arguments.Length >= 2)
+                amount = arguments[1];
 
             var receivingPlayer = client;
 

--- a/TrueCraft/Commands/HelpCommand.cs
+++ b/TrueCraft/Commands/HelpCommand.cs
@@ -29,8 +29,8 @@ namespace TrueCraft.Commands
 
             string Identifier;
 
-            if (arguments.Length > 1)
-                Identifier = arguments[1];
+            if (arguments.Length >= 1)
+                Identifier = arguments[0];
             else
                 Identifier = "0";
 

--- a/TrueCraft/Program.cs
+++ b/TrueCraft/Program.cs
@@ -148,7 +148,12 @@ namespace TrueCraft
 
             if (messageArray.Length <= 0) return false; // command not found
 
-            CommandManager.HandleCommand(e.Client, messageArray[0], messageArray);
+            var alias = messageArray[0];
+            var trimmedMessageArray = new string[messageArray.Length - 1];
+            if (trimmedMessageArray.Length != 0)
+                Array.Copy(messageArray, 1, trimmedMessageArray, 0, messageArray.Length - 1);
+
+            CommandManager.HandleCommand(e.Client, alias, trimmedMessageArray);
 
             return true;
         }


### PR DESCRIPTION
As @robinkanters suggested in the comment of 690ae82. I excluded the command/alias from the `arguments` array. I am not completely sure if I did it the way you'd like it, so tell me if something's wrong. I tested it and it works.