### PR TITLE
Do not use Thread.Abort

### DIFF
--- a/TrueCraft.Client/Rendering/Mesh.cs
+++ b/TrueCraft.Client/Rendering/Mesh.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace TrueCraft.Client.Rendering
 {
-    public class Mesh
+    public class Mesh : IDisposable
     {
         private bool Empty { get; set; }
         public object Data { get; set; }
@@ -34,10 +34,28 @@ namespace TrueCraft.Client.Rendering
 
         ~Mesh()
         {
-            if (Verticies != null)
-                Verticies.Dispose();
-            if (Indicies != null)
-                Indicies.Dispose();
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (Verticies != null)
+                    Verticies.Dispose();
+                if (Indicies != null)
+                    Indicies.Dispose();
+            }
+
+            Verticies = null;
+            Indicies = null;
         }
 
         public void Draw(Effect effect)


### PR DESCRIPTION
- Thread.Abort should be avoided as much as possible. Replaced it with a
CancellationToken instead.
- Mesh now implements IDisposable