### PR TITLE
Initial FNA project, with XNA4 compliance fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "externals/fNbt"]
 	path = externals/fNbt
 	url = https://github.com/SirCmpwn/fNbt.git
+[submodule "externals/FNA"]
+	path = externals/FNA
+	url = https://github.com/flibitijibibo/FNA.git

--- a/TrueCraft.Client/Events/ChunkEventArgs.cs
+++ b/TrueCraft.Client/Events/ChunkEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace TrueCraft.Client.Events
 {
-    public class ChunkEventArgs
+    public class ChunkEventArgs : EventArgs
     {
         public ReadOnlyChunk Chunk { get; set; }
 

--- a/TrueCraft.Client/Handlers/ChunkHandler.cs
+++ b/TrueCraft.Client/Handlers/ChunkHandler.cs
@@ -6,6 +6,7 @@ using TrueCraft.Core.World;
 using MonoGame.Utilities;
 using TrueCraft.Client.Events;
 using TrueCraft.API.World;
+using Ionic.Zlib;
 
 namespace TrueCraft.Client.Handlers
 {

--- a/TrueCraft.Client/Handlers/ChunkHandler.cs
+++ b/TrueCraft.Client/Handlers/ChunkHandler.cs
@@ -3,10 +3,13 @@ using TrueCraft.API.Networking;
 using TrueCraft.Core.Networking.Packets;
 using TrueCraft.API;
 using TrueCraft.Core.World;
-using MonoGame.Utilities;
 using TrueCraft.Client.Events;
 using TrueCraft.API.World;
+#if SDL2
 using Ionic.Zlib;
+#else
+using MonoGame.Utilities;
+#endif
 
 namespace TrueCraft.Client.Handlers
 {

--- a/TrueCraft.Client/Rendering/TextureMapper.cs
+++ b/TrueCraft.Client/Rendering/TextureMapper.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using TrueCraft.Core;
 using Ionic.Zip;
+#if !SDL2
 using MonoGame.Utilities.Png;
+#endif
 
 namespace TrueCraft.Client.Rendering
 {
@@ -29,8 +31,19 @@ namespace TrueCraft.Client.Rendering
         {
             Defaults.Clear();
 
+#if SDL2
+            using (FileStream items = File.OpenRead("Content/items.png"))
+            {
+                Defaults.Add("items.png", Texture2D.FromStream(graphicsDevice, items));
+            }
+            using (FileStream terrain = File.OpenRead("Content/terrain.png"))
+            {
+                Defaults.Add("terrain.png", Texture2D.FromStream(graphicsDevice, terrain));
+            }
+#else
             Defaults.Add("items.png", new PngReader().Read(File.OpenRead("Content/items.png"), graphicsDevice));
             Defaults.Add("terrain.png", new PngReader().Read(File.OpenRead("Content/terrain.png"), graphicsDevice));
+#endif
         }
 
         /// <summary>
@@ -104,7 +117,11 @@ namespace TrueCraft.Client.Rendering
                                 var ms = new MemoryStream();
                                 CopyStream(stream, ms);
                                 ms.Seek(0, SeekOrigin.Begin);
+#if SDL2
+                                AddTexture(key, Texture2D.FromStream(Device, ms));
+#else
                                 AddTexture(key, new PngReader().Read(ms, Device));
+#endif
                                 ms.Dispose();
                             }
                             catch (Exception ex) { Console.WriteLine("Exception occured while loading {0} from texture pack:\n\n{1}", key, ex); }

--- a/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
+++ b/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
@@ -80,10 +80,10 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
     <Reference Include="Ionic.Zip.Reduced">
       <HintPath>..\lib\Ionic.Zip.Reduced.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FNA\FNA.csproj">

--- a/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
+++ b/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
@@ -86,7 +86,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FNA\FNA.csproj">
+    <ProjectReference Include="..\externals\FNA\FNA.csproj">
       <Project>{35253CE1-C864-4CD3-8249-4D1319748E8F}</Project>
       <Name>FNA</Name>
     </ProjectReference>

--- a/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
+++ b/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
@@ -99,4 +99,42 @@
       <Name>TrueCraft.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Content\default-pack.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\default-pack.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\items.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\pack.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\pack.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\terrain.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Bold.fnt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Bold_0.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Italic.fnt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Italic_0.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Regular.fnt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Fonts\DejaVu_Regular_0.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
+++ b/TrueCraft.Client/TrueCraft.Client.SDL2.csproj
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TrueCraft.Client</RootNamespace>
+    <AssemblyName>TrueCraft.Client</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;WINDOWS;SDL2;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>none</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <ConsolePause>false</ConsolePause>
+    <DefineConstants>WINDOWS;SDL2;</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Input\KeyboardComponent.cs" />
+    <Compile Include="Input\KeyboardEventArgs.cs" />
+    <Compile Include="Input\KeyboardKeyEventArgs.cs" />
+    <Compile Include="Input\MouseButton.cs" />
+    <Compile Include="Input\MouseButtonEventArgs.cs" />
+    <Compile Include="Input\MouseComponent.cs" />
+    <Compile Include="Input\MouseEventArgs.cs" />
+    <Compile Include="Input\MouseMoveEventArgs.cs" />
+    <Compile Include="Input\MouseScrollEventArgs.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rendering\Camera.cs" />
+    <Compile Include="Rendering\Font.cs" />
+    <Compile Include="Rendering\FontRenderer.cs" />
+    <Compile Include="Rendering\FontStyle.cs" />
+    <Compile Include="Rendering\Renderer.cs" />
+    <Compile Include="Rendering\RendererEventArgs.cs" />
+    <Compile Include="Rendering\TextureMapper.cs" />
+    <Compile Include="TrueCraftGame.cs" />
+    <Compile Include="MultiplayerClient.cs" />
+    <Compile Include="Handlers\PacketHandlers.cs" />
+    <Compile Include="Events\ChatMessageEventArgs.cs" />
+    <Compile Include="Interface\ChatInterface.cs" />
+    <Compile Include="Interface\IGameInterface.cs" />
+    <Compile Include="BMFont.cs" />
+    <Compile Include="Handlers\ChunkHandler.cs" />
+    <Compile Include="ReadOnlyWorld.cs" />
+    <Compile Include="Events\ChunkEventArgs.cs" />
+    <Compile Include="PhysicsEngine.cs" />
+    <Compile Include="Rendering\Mesh.cs" />
+    <Compile Include="Rendering\BlockRenderer.cs" />
+    <Compile Include="Rendering\ChunkMesh.cs" />
+    <Compile Include="Rendering\Blocks\GrassRenderer.cs" />
+    <Compile Include="Rendering\Blocks\CraftingTableRenderer.cs" />
+    <Compile Include="Rendering\Blocks\TNTRenderer.cs" />
+    <Compile Include="Rendering\Blocks\SnowRenderer.cs" />
+    <Compile Include="Rendering\Blocks\TorchRenderer.cs" />
+    <Compile Include="Rendering\Blocks\LogRenderer.cs" />
+    <Compile Include="Rendering\ChunkRenderer.cs" />
+    <Compile Include="Rendering\Blocks\LeavesRenderer.cs" />
+    <Compile Include="Rendering\Blocks\TallGrassRenderer.cs" />
+    <Compile Include="Rendering\FlatQuadRenderer.cs" />
+    <Compile Include="Rendering\Blocks\LadderRenderer.cs" />
+    <Compile Include="Rendering\Blocks\SugarcaneRenderer.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Ionic.Zip.Reduced">
+      <HintPath>..\lib\Ionic.Zip.Reduced.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FNA\FNA.csproj">
+      <Project>{35253CE1-C864-4CD3-8249-4D1319748E8F}</Project>
+      <Name>FNA</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TrueCraft.API\TrueCraft.API.csproj">
+      <Project>{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}</Project>
+      <Name>TrueCraft.API</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TrueCraft.Core\TrueCraft.Core.csproj">
+      <Project>{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}</Project>
+      <Name>TrueCraft.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/TrueCraft.Client/TrueCraftGame.cs
+++ b/TrueCraft.Client/TrueCraftGame.cs
@@ -401,7 +401,7 @@ namespace TrueCraft.Client
 
             GraphicsDevice.Clear(Color.CornflowerBlue);
             SpriteBatch.Begin();
-            SpriteBatch.Draw(RenderTarget, new Vector2(0));
+            SpriteBatch.Draw(RenderTarget, Vector2.Zero, Color.White);
             SpriteBatch.End();
 
             base.Draw(gameTime);

--- a/TrueCraft.SDL2.sln
+++ b/TrueCraft.SDL2.sln
@@ -1,0 +1,50 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrueCraft", "TrueCraft\TrueCraft.csproj", "{C1C47EF5-2D8A-4231-AAA8-F651F52F480E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrueCraft.API", "TrueCraft.API\TrueCraft.API.csproj", "{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrueCraft.Core", "TrueCraft.Core\TrueCraft.Core.csproj", "{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrueCraft.Client.SDL2", "TrueCraft.Client\TrueCraft.Client.SDL2.csproj", "{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fNbt", "externals\fNbt\fNbt\fNbt.csproj", "{4488498D-976D-4DA3-BF72-109531AF0488}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FNA", "FNA\FNA.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}.Debug|x86.ActiveCfg = Debug|x86
+		{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}.Debug|x86.Build.0 = Debug|x86
+		{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}.Release|x86.ActiveCfg = Release|x86
+		{0D8E8F2D-74BB-4C91-AFE2-C6E33AA40FD4}.Release|x86.Build.0 = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.Build.0 = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.Build.0 = Release|x86
+		{4488498D-976D-4DA3-BF72-109531AF0488}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4488498D-976D-4DA3-BF72-109531AF0488}.Debug|x86.Build.0 = Debug|Any CPU
+		{4488498D-976D-4DA3-BF72-109531AF0488}.Release|x86.ActiveCfg = Release|Any CPU
+		{4488498D-976D-4DA3-BF72-109531AF0488}.Release|x86.Build.0 = Release|Any CPU
+		{C1C47EF5-2D8A-4231-AAA8-F651F52F480E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1C47EF5-2D8A-4231-AAA8-F651F52F480E}.Debug|x86.Build.0 = Debug|Any CPU
+		{C1C47EF5-2D8A-4231-AAA8-F651F52F480E}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1C47EF5-2D8A-4231-AAA8-F651F52F480E}.Release|x86.Build.0 = Release|Any CPU
+		{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA4BE9A3-DBF0-4380-BA2B-FFAA71C4706D}.Release|x86.Build.0 = Release|Any CPU
+		{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}.Debug|x86.Build.0 = Debug|Any CPU
+		{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}.Release|x86.ActiveCfg = Release|Any CPU
+		{FEE55B54-91B0-4325-A2C3-D576C0B7A81F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = TrueCraft\TrueCraft.csproj
+	EndGlobalSection
+EndGlobal

--- a/TrueCraft.SDL2.sln
+++ b/TrueCraft.SDL2.sln
@@ -11,7 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrueCraft.Client.SDL2", "Tr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fNbt", "externals\fNbt\fNbt\fNbt.csproj", "{4488498D-976D-4DA3-BF72-109531AF0488}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FNA", "FNA\FNA.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FNA", "externals\FNA\FNA.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This adds a `TrueCraft.SDL2.sln` project file, which for the most part looks like the original solution, but uses a new `TrueCraft.Client.SDL2.csproj` project file that uses FNA rather than MonoGame for its XNA reimplementation.

More information about FNA can be found here: http://fna-xna.github.io/

To build, simply clone FNA into the root of the TrueCraft repository and build the solution as you would the default solution.

In addition to the new projects, the source file changes are as follows:

- ChunkEventArgs: Buildfix to inherit EventArgs, for EventHandler compliance.
- ChunkHandler: Add Ionic using statement so the compiler knows where ZlibStream came from.
- TrueCraftGame: Use an official XNA4 SpriteBatch.Draw() method.
- TextureMapper: Rather than using the MonoGame PngReader, we'll instead use the official XNA4 method [Texture2D.FromStream](https://msdn.microsoft.com/en-us/library/ff434103.aspx), which essentially does the same thing.

There were other buildfixes I needed locally, but only because I use an ancient compiler for production.

Some caveats to the FNA solution:

- Totally untested! The precompiled C# assemblies were not happy with my Mono runtime, so I couldn't run it. XNA's XNA though, and since the game no longer uses threaded GL it should be just fine :)
- I did not include a launcher project. My system didn't have all the GTK dependencies (and there are a LOT of them...), so I didn't attempt to put this together - you'll have to manually set up the server/client with launch parameters for now.

Having an FNA version may be helpful for checking XNA4 compliance in addition to helping with portability - even if the platform support is roughly equivalent, having multiple XNA-like backends can be informative in identifying bugs that are uglier than usual (like that threaded GL one!).