### PR TITLE
Tweaked scaling, disabled smoothing of UI when scaled

### DIFF
--- a/TrueCraft.Client/Interface/ChatInterface.cs
+++ b/TrueCraft.Client/Interface/ChatInterface.cs
@@ -147,7 +147,7 @@ namespace TrueCraft.Client.Interface
         protected override void OnDrawSprites(GameTime gameTime, SpriteBatch spriteBatch)
         {
             // UI scaling
-            var scale = GetScaleFactor() * 1.5f;
+            var scale = GetScaleFactor();
             var xOrigin = (int)(10 * scale);
             var yOffset = (int)(25 * scale);
             var yOrigin = (int)(5 * scale) + (spriteBatch.GraphicsDevice.Viewport.Height - (yOffset * 7));

--- a/TrueCraft.Client/Interface/Control.cs
+++ b/TrueCraft.Client/Interface/Control.cs
@@ -101,14 +101,14 @@ namespace TrueCraft.Client.Interface
             switch (Scale)
             {
                 case InterfaceScale.Small:
-                    return 0.75f;
+                    return 0.5f;
 
                 default:
                 case InterfaceScale.Medium:
                     return 1.0f;
 
                 case InterfaceScale.Large:
-                    return 1.25f;
+                    return 1.5f;
             }
         }
     }

--- a/TrueCraft.Client/TrueCraftGame.cs
+++ b/TrueCraft.Client/TrueCraftGame.cs
@@ -440,7 +440,7 @@ namespace TrueCraft.Client
             DebugInterface.Vertices = verticies;
             DebugInterface.Chunks = chunks;
 
-            SpriteBatch.Begin();
+            SpriteBatch.Begin(SpriteSortMode.Deferred, null, SamplerState.PointClamp, null, null, null, null);
             for (int i = 0; i < Interfaces.Count; i++)
                 Interfaces[i].DrawSprites(gameTime, SpriteBatch);
             SpriteBatch.End();


### PR DESCRIPTION
The most common desktop resolution as of 2015 is 1366 x 768, so having the normal-scale chat window take up most the screen is a bit jarring. ```InterfaceScale.Large``` now equates to x 1.5.