### PR TITLE
Fixed sending DisconnectPacket before client exit

### DIFF
--- a/TrueCraft.Client/MultiplayerClient.cs
+++ b/TrueCraft.Client/MultiplayerClient.cs
@@ -111,9 +111,9 @@ namespace TrueCraft.Client
             if (!Connected)
                 return;
 
-            Interlocked.CompareExchange(ref connected, 0, 1);
-
             QueuePacket(new DisconnectPacket("Disconnecting"));
+            
+            Interlocked.CompareExchange(ref connected, 0, 1);
         }
 
         public void SendMessage(string message)


### PR DESCRIPTION
Because `Connected` was set to `false` before queuing the packet, the `DisconnectPacket` wasn't sent. (Look at lines 128, 129)