### PR TITLE
ConsoleLog outputs long text in multiple lines

### DIFF
--- a/TrueCraft.Core/Logging/ConsoleLogProvider.cs
+++ b/TrueCraft.Core/Logging/ConsoleLogProvider.cs
@@ -22,14 +22,38 @@ namespace TrueCraft.Core.Logging
                 Console.Write(category.ToString());
                 // Better to restore original than ResetColor
                 Console.ForegroundColor = currentColor;
-                // TODO: Check Console.BufferWidth and indent wrapping text onto the same level as the end of the timestamp
+
+                var buffer = Console.BufferWidth;
+                var offset = LogHelpers.GetTimestamp().Length;
+                var lineLength = buffer - offset;
                 // Longest LogCategory is Warning (length is 7 characters)
                 // The log will probably mostly contain messages belonging to the
                 // category Notice (6 chars). We want a pad of 4 spaces on average
                 // and also want the text to be aligned with the last message
                 // 7 + 4 = 11 is the max length of (category.ToString() + pad of 4 spaces)
-                Console.WriteLine(new string(' ', 11 - category.ToString().Length) + text, parameters);
+                var lines = getLines(new string(' ', 11) + text, lineLength, parameters); //Add all 11 chars for right alignment
+                lines[0] = lines[0].Remove(0, category.ToString().Length); //And remove the amount for category string
+                for (int i = 0; i < lines.Length; ++i)
+                {
+                    if (i != 0) Console.Write(new string(' ', offset));
+                    Console.Write(lines[i]);
+                }
             }
+        }
+        private string[] getLines(string text, int lineLength, params object[] parameters)
+        {
+            text = String.Format(text, parameters);
+            string[] lines = new string[(int)Math.Ceiling((double)text.Length / lineLength)];
+            int index = 0;
+            for (int i = 0; i < text.Length; i += lineLength)
+                if (text.Length - i >= lineLength)
+                    lines[index++] = text.Substring(i, lineLength);
+                else
+                    lines[index++] = text.Substring(i, text.Length - i);
+
+            if (lines[lines.Length - 1].Length < lineLength)
+                lines[lines.Length - 1] += "\n";
+            return lines;
         }
     }
 }

--- a/TrueCraft.Core/Logging/ConsoleLogProvider.cs
+++ b/TrueCraft.Core/Logging/ConsoleLogProvider.cs
@@ -23,33 +23,42 @@ namespace TrueCraft.Core.Logging
                 // Better to restore original than ResetColor
                 Console.ForegroundColor = currentColor;
 
-                var buffer = Console.BufferWidth;
-                var offset = LogHelpers.GetTimestamp().Length;
-                var lineLength = buffer - offset;
-                // Longest LogCategory is Warning (length is 7 characters)
-                // The log will probably mostly contain messages belonging to the
-                // category Notice (6 chars). We want a pad of 4 spaces on average
-                // and also want the text to be aligned with the last message
-                // 7 + 4 = 11 is the max length of (category.ToString() + pad of 4 spaces)
-                var lines = getLines(new string(' ', 11) + text, lineLength, parameters); //Add all 11 chars for right alignment
-                lines[0] = lines[0].Remove(0, category.ToString().Length); //And remove the amount for category string
-                for (int i = 0; i < lines.Length; ++i)
+                if(!Console.IsInputRedirected)
                 {
-                    if (i != 0) Console.Write(new string(' ', offset));
-                    Console.Write(lines[i]);
+                    Console.WriteLine(new string(' ', 11 - category.ToString().Length) + text, parameters);
+                }
+                else
+                {
+                    var buffer = Console.BufferWidth;
+                    var offset = LogHelpers.GetTimestamp().Length;
+                    var lineLength = buffer - offset;
+                    // Longest LogCategory is Warning (length is 7 characters)
+                    // The log will probably mostly contain messages belonging to the
+                    // category Notice (6 chars). We want a pad of 4 spaces on average
+                    // and also want the text to be aligned with the last message
+                    // 7 + 4 = 11 is the max length of (category.ToString() + pad of 4 spaces)
+                    var lines = GetLines(new string(' ', 11) + text, lineLength, parameters); //Add all 11 chars for right alignment
+                    lines[0] = lines[0].Remove(0, category.ToString().Length); //And remove the amount for category string
+                    for (int i = 0; i < lines.Length; ++i)
+                    {
+                        if (i != 0) Console.Write(new string(' ', offset));
+                        Console.Write(lines[i]);
+                    }
                 }
             }
         }
-        private string[] getLines(string text, int lineLength, params object[] parameters)
+        private string[] GetLines(string text, int lineLength, params object[] parameters)
         {
             text = String.Format(text, parameters);
             string[] lines = new string[(int)Math.Ceiling((double)text.Length / lineLength)];
             int index = 0;
             for (int i = 0; i < text.Length; i += lineLength)
+            {
                 if (text.Length - i >= lineLength)
                     lines[index++] = text.Substring(i, lineLength);
                 else
                     lines[index++] = text.Substring(i, text.Length - i);
+            }
 
             if (lines[lines.Length - 1].Length < lineLength)
                 lines[lines.Length - 1] += "\n";


### PR DESCRIPTION
Done according to:

    // TODO: Check Console.BufferWidth and indent wrapping text onto the same level as the end of the timestamp

![truecraftlines](https://cloud.githubusercontent.com/assets/10709060/8371658/b89a1f06-1bda-11e5-8796-8b29964784f7.jpg)

Tell me if you want it aligned differently.