### PR TITLE
Disconnect a crashed client

### DIFF
--- a/TrueCraft/RemoteClient.cs
+++ b/TrueCraft/RemoteClient.cs
@@ -283,6 +283,10 @@ namespace TrueCraft
                     e.SetBuffer(null, 0, 0);
                     break;
             }
+
+            if(Connection != null)
+                if (!Connection.Connected && !Disconnected)
+                    Server.DisconnectClient(this);
         }
 
         private void ProcessNetwork(SocketAsyncEventArgs e)


### PR DESCRIPTION
When client crashes the Socket `Connection` closes, but server didn't check if client has previously disconnected.