### PR TITLE
Merge lighting improvements

### DIFF
--- a/TrueCraft.Client/Modules/ChunkModule.cs
+++ b/TrueCraft.Client/Modules/ChunkModule.cs
@@ -36,10 +36,6 @@ namespace TrueCraft.Client.Modules
             ChunkRenderer.Start();
 
             OpaqueEffect = new BasicEffect(Game.GraphicsDevice);
-            OpaqueEffect.EnableDefaultLighting();
-            OpaqueEffect.DirectionalLight0.SpecularColor = Color.Black.ToVector3();
-            OpaqueEffect.DirectionalLight1.SpecularColor = Color.Black.ToVector3();
-            OpaqueEffect.DirectionalLight2.SpecularColor = Color.Black.ToVector3();
             OpaqueEffect.TextureEnabled = true;
             OpaqueEffect.Texture = Game.TextureMapper.GetTexture("terrain.png");
             OpaqueEffect.FogEnabled = true;

--- a/TrueCraft.Client/Rendering/BlockRenderer.cs
+++ b/TrueCraft.Client/Rendering/BlockRenderer.cs
@@ -42,8 +42,6 @@ namespace TrueCraft.Client.Rendering
             return CreateUniformCube(offset, texture, faces, indiciesOffset, out indicies, Color.White, descriptor.BlockLight);
         }
 
-        public static readonly Random Random = new Random();
-
         public static VertexPositionNormalColorTexture[] CreateUniformCube(Vector3 offset, Vector2[] texture,
             VisibleFaces faces, int indiciesOffset, out int[] indicies, Color color, int light = 15)
         {

--- a/TrueCraft.Client/Rendering/BlockRenderer.cs
+++ b/TrueCraft.Client/Rendering/BlockRenderer.cs
@@ -39,11 +39,13 @@ namespace TrueCraft.Client.Rendering
             };
             for (int i = 0; i < texture.Length; i++)
                 texture[i] *= new Vector2(16f / 256f);
-            return CreateUniformCube(offset, texture, faces, indiciesOffset, out indicies, Color.White);
+            return CreateUniformCube(offset, texture, faces, indiciesOffset, out indicies, Color.White, descriptor.BlockLight);
         }
 
+        public static readonly Random Random = new Random();
+
         public static VertexPositionNormalColorTexture[] CreateUniformCube(Vector3 offset, Vector2[] texture,
-            VisibleFaces faces, int indiciesOffset, out int[] indicies, Color color)
+            VisibleFaces faces, int indiciesOffset, out int[] indicies, Color color, int light = 15)
         {
             faces = VisibleFaces.All; // Temporary
 
@@ -70,7 +72,7 @@ namespace TrueCraft.Client.Rendering
                 }
                 var side = (CubeFace)_side;
                 var quad = CreateQuad(side, offset, texture, textureIndex % texture.Length, indiciesOffset,
-                    out _indicies, color);
+                    out _indicies, new Color(color.ToVector3() * CubeBrightness[light]));
                 Array.Copy(quad, 0, verticies, sidesSoFar * 4, 4);
                 Array.Copy(_indicies, 0, indicies, sidesSoFar * 6, 6);
                 textureIndex += 4;
@@ -102,6 +104,15 @@ namespace TrueCraft.Client.Rendering
                 0.6f, 0.6f, // North / South
                 0.8f, 0.8f, // East / West
                 1.0f, 0.5f  // Top / Bottom
+            };
+
+        protected static readonly float[] CubeBrightness =
+            new float[]
+            {
+                0.050f, 0.067f, 0.085f, 0.106f, // [ 0..3 ]
+                0.129f, 0.156f, 0.186f, 0.221f, // [ 4..7 ]
+                0.261f, 0.309f, 0.367f, 0.437f, // [ 8..11]
+                0.525f, 0.638f, 0.789f, 1.000f //  [12..15]
             };
 
         protected enum CubeFace

--- a/TrueCraft.Client/Rendering/BlockRenderer.cs
+++ b/TrueCraft.Client/Rendering/BlockRenderer.cs
@@ -88,12 +88,21 @@ namespace TrueCraft.Client.Rendering
             var quad = new VertexPositionNormalColorTexture[4];
             var unit = CubeMesh[(int)face];
             var normal = CubeNormals[(int)face];
+            var faceColor = new Color(FaceBrightness[(int)face] * color.ToVector3());
             for (int i = 0; i < 4; i++)
             {
-                quad[i] = new VertexPositionNormalColorTexture(offset + unit[i], normal, color, texture[textureOffset + i]);
+                quad[i] = new VertexPositionNormalColorTexture(offset + unit[i], normal, faceColor, texture[textureOffset + i]);
             }
             return quad;
         }
+        
+        protected static readonly float[] FaceBrightness =
+            new float[]
+            {
+                0.6f, 0.6f, // North / South
+                0.8f, 0.8f, // East / West
+                1.0f, 0.5f  // Top / Bottom
+            };
 
         protected enum CubeFace
         {

--- a/TrueCraft.Client/Rendering/Blocks/GrassRenderer.cs
+++ b/TrueCraft.Client/Rendering/Blocks/GrassRenderer.cs
@@ -107,7 +107,7 @@ namespace TrueCraft.Client.Rendering.Blocks
             // Apply biome colors to top of cube
             for (int i = (int)(CubeFace.PositiveY) * 4; i < (int)(CubeFace.PositiveY) * 4 + 4; i++)
             {
-                cube[i].Color = BiomeColor; // TODO: Take this from biome
+                cube[i].Color = new Color(cube[i].Color.ToVector3() * BiomeColor.ToVector3()); // TODO: Take this from biome
             }
             return cube;
         }

--- a/TrueCraft.Client/TrueCraft.Client.csproj
+++ b/TrueCraft.Client/TrueCraft.Client.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\targets\Client.targets" />
   <PropertyGroup>
@@ -379,8 +379,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Modules\" />
-    <Folder Include="Content\Audio\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
Block vertices are colored properly now. Once ReadOnlyWorld provides actual light values, block rendering should handle it without any extra modifications.