### PR TITLE
Minor no-op changes for the compiler and/or XNA

### DIFF
--- a/TrueCraft.Client/AudioManager.cs
+++ b/TrueCraft.Client/AudioManager.cs
@@ -117,9 +117,7 @@ namespace TrueCraft.Client
         public void PlayPack(string pack, float volume = 1.0f)
         {
             var i = MathHelper.Random.Next(0, AudioPacks[pack].Length);
-            var instance = AudioPacks[pack][i].CreateInstance();
-            instance.Volume = volume * EffectVolume;
-            instance.Play();
+            AudioPacks[pack][i].Play(volume * EffectVolume, 1.0f, 0.0f);
         }
     }
 }

--- a/TrueCraft.Client/Events/ChunkEventArgs.cs
+++ b/TrueCraft.Client/Events/ChunkEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace TrueCraft.Client.Events
 {
-    public class ChunkEventArgs
+    public class ChunkEventArgs : EventArgs
     {
         public ReadOnlyChunk Chunk { get; set; }
 

--- a/TrueCraft.Client/TrueCraftGame.cs
+++ b/TrueCraft.Client/TrueCraftGame.cs
@@ -411,7 +411,7 @@ namespace TrueCraft.Client
             GraphicsDevice.SetRenderTarget(null);
 
             SpriteBatch.Begin();
-            SpriteBatch.Draw(RenderTarget, new Vector2(0));
+            SpriteBatch.Draw(RenderTarget, Vector2.Zero, Color.White);
             SpriteBatch.End();
 
             base.Draw(gameTime);


### PR DESCRIPTION
Full list of changes:

- Fix the SoundEffectInstance leak as reported in #210
- ChunkEventArgs now extends EventArgs explicitly, which is needed by older Mono compilers
- The SpriteBatch.Draw function in TrueCraftGame now uses an overload found in XNA; the functionality is the same as before (though in MonoGame this avoids a redundant assignment of Color.White, sooo microoptimization? :D )