### PR TITLE
Gtk to Gtk3

### DIFF
--- a/TrueCraft.Launcher/Program.cs
+++ b/TrueCraft.Launcher/Program.cs
@@ -14,7 +14,7 @@ namespace TrueCraft.Launcher
         public static void Main(string[] args)
         {
             if (RuntimeInfo.IsLinux)
-                Application.Initialize(ToolkitType.Gtk);
+                Application.Initialize(ToolkitType.Gtk3);
             else if (RuntimeInfo.IsMacOSX)
                 Application.Initialize(ToolkitType.Gtk); // TODO: Cocoa
             else if (RuntimeInfo.IsWindows)


### PR DESCRIPTION
This allows for compiling on modern Linux distributions (such as Solus). By doing this it fixes the game crashing because it can't find libwebkitgtk-1.0. Also Gtk3 brings it one more step of the way to be compatible with Wayland. 

Must have bellow package installed
https://github.com/mono/gtk-sharp